### PR TITLE
Improve visualisation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,25 +1,29 @@
 import './App.css';
-import { BrowserRouter, Route, Routes } from "react-router-dom";
-import { WelcomePage } from "./WelcomePage.tsx";
-import { OptimizerPage } from "./Optimizer/OptimizerPage.tsx";
-import { NoPage } from "./NoPage.tsx";
-import { Layout } from "./Layout.tsx";
-import { PresentationPage } from "./Presentation/PresentationPage.tsx";
-import { DataImporterPage } from './DataImporter/DataImporterPage.tsx';
+import {BrowserRouter, Route, Routes} from "react-router-dom";
+import {WelcomePage} from "./WelcomePage.tsx";
+import {OptimizerPage} from "./Optimizer/OptimizerPage.tsx";
+import {NoPage} from "./NoPage.tsx";
+import {Layout} from "./Layout.tsx";
+import {PresentationPage} from "./Presentation/PresentationPage.tsx";
+import {DataImporterPage} from './DataImporter/DataImporterPage.tsx';
+import {NetworkProvider} from "./NetworkModel/NetworkContext.tsx";
 
 function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={<WelcomePage />} />
-          <Route path="import" element={<DataImporterPage />} />
-          <Route path="optimizer" element={<OptimizerPage />} />
-          <Route path="presentation" element={<PresentationPage />} />
-          <Route path="*" element={<NoPage />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <NetworkProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Layout/>}>
+            <Route index element={<WelcomePage/>}/>
+            <Route path="import" element={<DataImporterPage/>}/>
+            <Route path="optimizer" element={<OptimizerPage/>}/>
+            <Route path="presentation" element={<PresentationPage/>}/>
+            <Route path="*" element={<NoPage/>}/>
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </NetworkProvider>
+
   );
 }
 

--- a/frontend/src/DataImporter/DataImporterPage.tsx
+++ b/frontend/src/DataImporter/DataImporterPage.tsx
@@ -2,8 +2,12 @@ import {useEffect, useState} from "react";
 import {CsvUpload} from "./CsvUpload.tsx";
 import {parseEdges, parseEdgeSpectrum, parseNodes} from "./parseCsv.ts";
 import {buildNetwork} from "./buildNetwork.ts";
+import {useNetwork} from "../NetworkModel/NetworkContext.tsx";
+import {demoNetwork} from "../NetworkModel/demoNetwork.ts";
 
 export const DataImporterPage = () => {
+  const {setNetwork} = useNetwork();
+
   const [message, setMessage] = useState<string | null>("");
   const [nodesCsv, setNodesCsv] = useState<string | null>(null);
   const [edgesCsv, setEdgesCsv] = useState<string | null>(null);
@@ -12,6 +16,9 @@ export const DataImporterPage = () => {
   useEffect(() => {
     if (nodesCsv && edgesCsv && spectrumCsv) {
       try {
+        setNetwork(demoNetwork);
+        console.log("Set demo network");
+
         const nodesData = parseNodes(nodesCsv);
         const edgesData = parseEdges(edgesCsv);
         const spectrumData = parseEdgeSpectrum(spectrumCsv);

--- a/frontend/src/NetworkModel/NetworkContext.tsx
+++ b/frontend/src/NetworkModel/NetworkContext.tsx
@@ -4,15 +4,18 @@ import {Network} from "./network.ts";
 interface NetworkContextType {
   network: Network | null;
   setNetwork: (network: Network | null) => void;
+  highlightedChannelId: string | null;
+  setHighlightedChannelId: (channelId: string | null) => void;
 }
 
 const NetworkContext = createContext<NetworkContextType | undefined>(undefined);
 
 export const NetworkProvider = ({ children }: { children: ReactNode }) => {
   const [network, setNetwork] = useState<Network | null>(null);
+  const [highlightedChannelId, setHighlightedChannelId] = useState<string | null>(null);
 
   return (
-    <NetworkContext.Provider value={{ network, setNetwork }}>
+    <NetworkContext.Provider value={{ network, setNetwork, highlightedChannelId, setHighlightedChannelId }}>
       {children}
     </NetworkContext.Provider>
   );

--- a/frontend/src/NetworkModel/NetworkContext.tsx
+++ b/frontend/src/NetworkModel/NetworkContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import {Network} from "./network.ts";
+
+interface NetworkContextType {
+  network: Network | null;
+  setNetwork: (network: Network | null) => void;
+}
+
+const NetworkContext = createContext<NetworkContextType | undefined>(undefined);
+
+export const NetworkProvider = ({ children }: { children: ReactNode }) => {
+  const [network, setNetwork] = useState<Network | null>(null);
+
+  return (
+    <NetworkContext.Provider value={{ network, setNetwork }}>
+      {children}
+    </NetworkContext.Provider>
+  );
+};
+
+export const useNetwork = (): NetworkContextType => {
+  const context = useContext(NetworkContext);
+  if (!context) {
+    throw new Error('useNetwork must be used within a NetworkProvider');
+  }
+  return context;
+};

--- a/frontend/src/NetworkModel/calcNodeDistance.test.ts
+++ b/frontend/src/NetworkModel/calcNodeDistance.test.ts
@@ -1,0 +1,24 @@
+import {calcNodeDistance} from './calcNodeDistance';
+import {Node} from './network';
+
+describe('calcNodeDistance', () => {
+  it('should calculate the distance between Warsaw and Krakow', () => {
+    const warsaw: Node = {
+      id: '1',
+      latitude: 52.2297,
+      longitude: 21.0122,
+      neighbors: []
+    };
+
+    const krakow: Node = {
+      id: '2',
+      latitude: 50.0647,
+      longitude: 19.9450,
+      neighbors: []
+    };
+
+    const distance = calcNodeDistance(warsaw, krakow);
+
+    expect(distance).toBeCloseTo(252, 0);
+  });
+});

--- a/frontend/src/NetworkModel/calcNodeDistance.ts
+++ b/frontend/src/NetworkModel/calcNodeDistance.ts
@@ -1,0 +1,27 @@
+import {Node} from "./network";
+
+/**
+ * Calculate the distance in kilometers between two nodes using the Haversine formula
+ * @param nodeA
+ * @param nodeB
+ */
+export const calcNodeDistance = (nodeA: Node, nodeB: Node): number => {
+  const R = 6371; // Radius of the Earth in kilometers
+  const lat1 = nodeA.latitude;
+  const lon1 = nodeA.longitude;
+  const lat2 = nodeB.latitude;
+  const lon2 = nodeB.longitude;
+
+  const dLat = toRadians(lat2 - lat1);
+  const dLon = toRadians(lon2 - lon1);
+
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) *
+    Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+const toRadians = (degree: number) => degree * (Math.PI / 180);

--- a/frontend/src/NetworkModel/demoNetwork.ts
+++ b/frontend/src/NetworkModel/demoNetwork.ts
@@ -2,13 +2,13 @@ import { Network, Node, Edge, Channel } from './network';
 
 const nodes: Record<string, Node> = {
   'N1': { id: 'N1', latitude: 52.2297, longitude: 21.0122, neighbors: ['N2', 'N4', 'N6', 'N9'] }, // Warsaw
-  'N2': { id: 'N2', latitude: 50.0647, longitude: 19.9450, neighbors: ['N1', 'N3', 'N5', 'N7'] }, // Krakow
-  'N3': { id: 'N3', latitude: 51.1079, longitude: 17.0385, neighbors: ['N2', 'N4', 'N5'] }, // Wroclaw
-  'N4': { id: 'N4', latitude: 51.7592, longitude: 19.4560, neighbors: ['N1', 'N3', 'N5'] }, // Lodz
-  'N5': { id: 'N5', latitude: 50.2649, longitude: 19.0238, neighbors: ['N2', 'N3', 'N4', 'N6'] }, // Katowice
-  'N6': { id: 'N6', latitude: 53.1325, longitude: 23.1688, neighbors: ['N1', 'N5', 'N7'] }, // Bialystok
-  'N7': { id: 'N7', latitude: 50.0413, longitude: 21.9990, neighbors: ['N6', 'N8'] }, // Rzeszow
-  'N8': { id: 'N8', latitude: 53.4285, longitude: 14.5528, neighbors: ['N7', 'N9'] }, // Szczecin
+  'N2': { id: 'N2', latitude: 50.0647, longitude: 19.9450, neighbors: ['N1', 'N4', 'N5', 'N7'] }, // Krakow
+  'N3': { id: 'N3', latitude: 51.1079, longitude: 17.0385, neighbors: ['N4', 'N5'] }, // Wroclaw
+  'N4': { id: 'N4', latitude: 51.7592, longitude: 19.4560, neighbors: ['N1', 'N2', 'N3', 'N5'] }, // Lodz
+  'N5': { id: 'N5', latitude: 50.2649, longitude: 19.0238, neighbors: ['N2', 'N3', 'N4'] }, // Katowice
+  'N6': { id: 'N6', latitude: 53.1325, longitude: 23.1688, neighbors: ['N1', 'N7'] }, // Bialystok
+  'N7': { id: 'N7', latitude: 50.0413, longitude: 21.9990, neighbors: ['N6'] }, // Rzeszow
+  'N8': { id: 'N8', latitude: 53.4285, longitude: 14.5528, neighbors: ['N9'] }, // Szczecin
   'N9': { id: 'N9', latitude: 54.3520, longitude: 18.6466, neighbors: ['N1', 'N8'] }, // Gdansk
 };
 
@@ -17,16 +17,14 @@ const edges: Record<string, Edge> = {
   'E2': { id: 'E2', node1Id: 'N1', node2Id: 'N4', totalCapacity: '100Gbps', provisionedCapacity: 50 },
   'E3': { id: 'E3', node1Id: 'N1', node2Id: 'N6', totalCapacity: '100Gbps', provisionedCapacity: 50 },
   'E4': { id: 'E4', node1Id: 'N1', node2Id: 'N9', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  'E5': { id: 'E5', node1Id: 'N2', node2Id: 'N3', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E5': { id: 'E5', node1Id: 'N2', node2Id: 'N4', totalCapacity: '100Gbps', provisionedCapacity: 50 },
   'E6': { id: 'E6', node1Id: 'N2', node2Id: 'N5', totalCapacity: '100Gbps', provisionedCapacity: 50 },
   'E7': { id: 'E7', node1Id: 'N2', node2Id: 'N7', totalCapacity: '100Gbps', provisionedCapacity: 50 },
   'E8': { id: 'E8', node1Id: 'N3', node2Id: 'N4', totalCapacity: '100Gbps', provisionedCapacity: 50 },
   'E9': { id: 'E9', node1Id: 'N3', node2Id: 'N5', totalCapacity: '100Gbps', provisionedCapacity: 50 },
   'E10': { id: 'E10', node1Id: 'N4', node2Id: 'N5', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  'E11': { id: 'E11', node1Id: 'N5', node2Id: 'N6', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  'E12': { id: 'E12', node1Id: 'N6', node2Id: 'N7', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  'E13': { id: 'E13', node1Id: 'N7', node2Id: 'N8', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  'E14': { id: 'E14', node1Id: 'N8', node2Id: 'N9', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E11': { id: 'E11', node1Id: 'N6', node2Id: 'N7', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E12': { id: 'E12', node1Id: 'N8', node2Id: 'N9', totalCapacity: '100Gbps', provisionedCapacity: 50 },
 };
 
 const channels: Record<string, Channel> = {

--- a/frontend/src/NetworkModel/demoNetwork.ts
+++ b/frontend/src/NetworkModel/demoNetwork.ts
@@ -1,0 +1,42 @@
+import { Network, Node, Edge, Channel } from './network';
+
+const nodes: Record<string, Node> = {
+  '1': { id: '1', latitude: 52.2297, longitude: 21.0122, neighbors: ['2', '4', '6', '9'] }, // Warsaw
+  '2': { id: '2', latitude: 50.0647, longitude: 19.9450, neighbors: ['1', '3', '5', '7'] }, // Krakow
+  '3': { id: '3', latitude: 51.1079, longitude: 17.0385, neighbors: ['2', '4', '5'] }, // Wroclaw
+  '4': { id: '4', latitude: 51.7592, longitude: 19.4560, neighbors: ['1', '3', '5'] }, // Lodz
+  '5': { id: '5', latitude: 50.2649, longitude: 19.0238, neighbors: ['2', '3', '4', '6'] }, // Katowice
+  '6': { id: '6', latitude: 53.1325, longitude: 23.1688, neighbors: ['1', '5', '7'] }, // Bialystok
+  '7': { id: '7', latitude: 50.0413, longitude: 21.9990, neighbors: ['6', '8'] }, // Rzeszow
+  '8': { id: '8', latitude: 53.4285, longitude: 14.5528, neighbors: ['7', '9'] }, // Szczecin
+  '9': { id: '9', latitude: 54.3520, longitude: 18.6466, neighbors: ['1', '8'] }, // Gdansk
+};
+
+const edges: Record<string, Edge> = {
+  '1': { id: '1', node1Id: '1', node2Id: '2', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  '2': { id: '2', node1Id: '1', node2Id: '4', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  '3': { id: '3', node1Id: '1', node2Id: '6', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  '4': { id: '4', node1Id: '1', node2Id: '9', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  '5': { id: '5', node1Id: '2', node2Id: '3', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  '6': { id: '6', node1Id: '2', node2Id: '5', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  '7': { id: '7', node1Id: '2', node2Id: '7', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  '8': { id: '8', node1Id: '3', node2Id: '4', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  '9': { id: '9', node1Id: '3', node2Id: '5', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  '10': { id: '10', node1Id: '4', node2Id: '5', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  '11': { id: '11', node1Id: '5', node2Id: '6', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  '12': { id: '12', node1Id: '6', node2Id: '7', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  '13': { id: '13', node1Id: '7', node2Id: '8', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  '14': { id: '14', node1Id: '8', node2Id: '9', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+};
+
+const channels: Record<string, Channel> = {
+  '1': { id: '1', nodes: ['9', '1', '4', '3'], edges: ['4', '2', '8'], frequency: 195.45, width: 50.0 }, // Gdansk-Warsaw-Lodz-Wroclaw
+  '2': { id: '2', nodes: ['6', '1', '4', '5'], edges: ['3', '2', '10'], frequency: 195.3, width: 75.0 }, // Bialystok-Warsaw-Lodz-Katowice
+};
+
+export const demoNetwork: Network = {
+  nodes,
+  edges,
+  channels,
+};
+

--- a/frontend/src/NetworkModel/demoNetwork.ts
+++ b/frontend/src/NetworkModel/demoNetwork.ts
@@ -1,37 +1,37 @@
 import { Network, Node, Edge, Channel } from './network';
 
 const nodes: Record<string, Node> = {
-  '1': { id: '1', latitude: 52.2297, longitude: 21.0122, neighbors: ['2', '4', '6', '9'] }, // Warsaw
-  '2': { id: '2', latitude: 50.0647, longitude: 19.9450, neighbors: ['1', '3', '5', '7'] }, // Krakow
-  '3': { id: '3', latitude: 51.1079, longitude: 17.0385, neighbors: ['2', '4', '5'] }, // Wroclaw
-  '4': { id: '4', latitude: 51.7592, longitude: 19.4560, neighbors: ['1', '3', '5'] }, // Lodz
-  '5': { id: '5', latitude: 50.2649, longitude: 19.0238, neighbors: ['2', '3', '4', '6'] }, // Katowice
-  '6': { id: '6', latitude: 53.1325, longitude: 23.1688, neighbors: ['1', '5', '7'] }, // Bialystok
-  '7': { id: '7', latitude: 50.0413, longitude: 21.9990, neighbors: ['6', '8'] }, // Rzeszow
-  '8': { id: '8', latitude: 53.4285, longitude: 14.5528, neighbors: ['7', '9'] }, // Szczecin
-  '9': { id: '9', latitude: 54.3520, longitude: 18.6466, neighbors: ['1', '8'] }, // Gdansk
+  'N1': { id: 'N1', latitude: 52.2297, longitude: 21.0122, neighbors: ['N2', 'N4', 'N6', 'N9'] }, // Warsaw
+  'N2': { id: 'N2', latitude: 50.0647, longitude: 19.9450, neighbors: ['N1', 'N3', 'N5', 'N7'] }, // Krakow
+  'N3': { id: 'N3', latitude: 51.1079, longitude: 17.0385, neighbors: ['N2', 'N4', 'N5'] }, // Wroclaw
+  'N4': { id: 'N4', latitude: 51.7592, longitude: 19.4560, neighbors: ['N1', 'N3', 'N5'] }, // Lodz
+  'N5': { id: 'N5', latitude: 50.2649, longitude: 19.0238, neighbors: ['N2', 'N3', 'N4', 'N6'] }, // Katowice
+  'N6': { id: 'N6', latitude: 53.1325, longitude: 23.1688, neighbors: ['N1', 'N5', 'N7'] }, // Bialystok
+  'N7': { id: 'N7', latitude: 50.0413, longitude: 21.9990, neighbors: ['N6', 'N8'] }, // Rzeszow
+  'N8': { id: 'N8', latitude: 53.4285, longitude: 14.5528, neighbors: ['N7', 'N9'] }, // Szczecin
+  'N9': { id: 'N9', latitude: 54.3520, longitude: 18.6466, neighbors: ['N1', 'N8'] }, // Gdansk
 };
 
 const edges: Record<string, Edge> = {
-  '1': { id: '1', node1Id: '1', node2Id: '2', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  '2': { id: '2', node1Id: '1', node2Id: '4', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  '3': { id: '3', node1Id: '1', node2Id: '6', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  '4': { id: '4', node1Id: '1', node2Id: '9', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  '5': { id: '5', node1Id: '2', node2Id: '3', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  '6': { id: '6', node1Id: '2', node2Id: '5', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  '7': { id: '7', node1Id: '2', node2Id: '7', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  '8': { id: '8', node1Id: '3', node2Id: '4', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  '9': { id: '9', node1Id: '3', node2Id: '5', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  '10': { id: '10', node1Id: '4', node2Id: '5', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  '11': { id: '11', node1Id: '5', node2Id: '6', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  '12': { id: '12', node1Id: '6', node2Id: '7', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  '13': { id: '13', node1Id: '7', node2Id: '8', totalCapacity: '100Gbps', provisionedCapacity: 50 },
-  '14': { id: '14', node1Id: '8', node2Id: '9', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E1': { id: 'E1', node1Id: 'N1', node2Id: 'N2', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E2': { id: 'E2', node1Id: 'N1', node2Id: 'N4', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E3': { id: 'E3', node1Id: 'N1', node2Id: 'N6', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E4': { id: 'E4', node1Id: 'N1', node2Id: 'N9', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E5': { id: 'E5', node1Id: 'N2', node2Id: 'N3', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E6': { id: 'E6', node1Id: 'N2', node2Id: 'N5', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E7': { id: 'E7', node1Id: 'N2', node2Id: 'N7', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E8': { id: 'E8', node1Id: 'N3', node2Id: 'N4', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E9': { id: 'E9', node1Id: 'N3', node2Id: 'N5', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E10': { id: 'E10', node1Id: 'N4', node2Id: 'N5', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E11': { id: 'E11', node1Id: 'N5', node2Id: 'N6', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E12': { id: 'E12', node1Id: 'N6', node2Id: 'N7', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E13': { id: 'E13', node1Id: 'N7', node2Id: 'N8', totalCapacity: '100Gbps', provisionedCapacity: 50 },
+  'E14': { id: 'E14', node1Id: 'N8', node2Id: 'N9', totalCapacity: '100Gbps', provisionedCapacity: 50 },
 };
 
 const channels: Record<string, Channel> = {
-  '1': { id: '1', nodes: ['9', '1', '4', '3'], edges: ['4', '2', '8'], frequency: 195.45, width: 50.0 }, // Gdansk-Warsaw-Lodz-Wroclaw
-  '2': { id: '2', nodes: ['6', '1', '4', '5'], edges: ['3', '2', '10'], frequency: 195.3, width: 75.0 }, // Bialystok-Warsaw-Lodz-Katowice
+  'C1': { id: 'C1', nodes: ['N9', 'N1', 'N4', 'N3'], edges: ['E4', 'E2', 'E8'], frequency: 195.45, width: 50.0 }, // Gdansk-Warsaw-Lodz-Wroclaw
+  'C2': { id: 'C2', nodes: ['N6', 'N1', 'N4', 'N5'], edges: ['E3', 'E2', 'E10'], frequency: 195.3, width: 75.0 }, // Bialystok-Warsaw-Lodz-Katowice
 };
 
 export const demoNetwork: Network = {

--- a/frontend/src/NetworkModel/network.ts
+++ b/frontend/src/NetworkModel/network.ts
@@ -1,0 +1,28 @@
+export interface Edge {
+  id: string;
+  node1Id: string;
+  node2Id: string;
+  totalCapacity: string;
+  provisionedCapacity: number;
+}
+
+export interface Node {
+  id: string;
+  latitude: number;
+  longitude: number;
+  neighbors: string[];
+}
+
+export interface Channel {
+  id: string;
+  nodes: string[];
+  edges: string[];
+  frequency: number;
+  width: number;
+}
+
+export interface Network {
+  nodes: Record<string, Node>;
+  edges: Record<string, Edge>;
+  channels: Record<string, Channel>;
+}

--- a/frontend/src/Presentation/GraphVisualisationDemo.tsx
+++ b/frontend/src/Presentation/GraphVisualisationDemo.tsx
@@ -1,25 +1,29 @@
 import {GraphCanvas, InternalGraphEdge, InternalGraphNode} from "reagraph";
 import {useState} from "react";
+import {demoNetwork} from "../NetworkModel/demoNetwork.ts";
 
 export const GraphVisualisationDemo = () => {
   const [text, setText] = useState("");
+  const network = demoNetwork;
 
-  const nodes = [
-    {id: '1', label: '1', x: 100, y: 100},
-    {id: '2', label: '2', x: 200, y: 100},
-    {id: '3', label: '3', x: 300, y: 100},
-    {id: '4', label: '4', x: 400, y: 100},
-    {id: '5', label: '5', x: 500, y: 100}
-  ];
+  const nodes = Object.values(network.nodes).map(node => {
+    return {
+      id: node.id,
+      label: node.id,
+      x: node.longitude,
+      y: node.latitude
+    };
+  });
 
-  const edges = [
-    {source: '1', target: '2', id: '1-2', label: '1-2'},
-    {source: '2', target: '1', id: '2-1', label: '2-1'},
-    {source: '1', target: '3', id: '1-3', label: '1-3'},
-    {source: '3', target: '4', id: '3-4', label: '3-4'},
-    {source: '4', target: '5', id: '4-5', label: '4-5'},
-    {source: '5', target: '1', id: '5-1', label: '5-1'}
-  ];
+  const edges = Object.values(network.edges).map(edge => {
+    return {
+      source: edge.node1Id,
+      target: edge.node2Id,
+      id: edge.id,
+      label: `${edge.node1Id}-${edge.node2Id}`
+    };
+  });
+
 
   const handleNodeClick = (node: InternalGraphNode) => {
     console.log(node);

--- a/frontend/src/Presentation/GraphVisualisationDemo.tsx
+++ b/frontend/src/Presentation/GraphVisualisationDemo.tsx
@@ -1,4 +1,4 @@
-import {GraphCanvas, InternalGraphEdge, InternalGraphNode, NodeRendererProps} from "reagraph";
+import {GraphCanvas, InternalGraphEdge, InternalGraphNode} from "reagraph";
 import {useState} from "react";
 import {useNetwork} from "../NetworkModel/NetworkContext.tsx";
 
@@ -18,7 +18,7 @@ export const GraphVisualisationDemo = () => {
       label: node.id,
       x: node.longitude,
       y: node.latitude,
-      fill: "#FF0000"
+      fill: highlightedChannel?.nodes.includes(node.id) ? "#FF0000" : "#0000FF"
     };
   });
 
@@ -28,7 +28,7 @@ export const GraphVisualisationDemo = () => {
       target: edge.node2Id,
       id: edge.id,
       label: `${edge.node1Id}-${edge.node2Id}`,
-      fill: '#FF0000'
+      fill: highlightedChannel?.edges.includes(edge.id) ? "#FF0000" : "#0000FF"
     };
   });
 
@@ -53,7 +53,6 @@ export const GraphVisualisationDemo = () => {
           onNodeClick={handleNodeClick}
           onEdgeClick={handleEdgeClick}
           edgeArrowPosition={"none"}
-          actives={highlightedChannel?.edges}
         />
       </div>
     </>

--- a/frontend/src/Presentation/GraphVisualisationDemo.tsx
+++ b/frontend/src/Presentation/GraphVisualisationDemo.tsx
@@ -11,7 +11,8 @@ export const GraphVisualisationDemo = () => {
       id: node.id,
       label: node.id,
       x: node.longitude,
-      y: node.latitude
+      y: node.latitude,
+      color: '#FF0000'
     };
   });
 
@@ -20,7 +21,7 @@ export const GraphVisualisationDemo = () => {
       source: edge.node1Id,
       target: edge.node2Id,
       id: edge.id,
-      label: `${edge.node1Id}-${edge.node2Id}`
+      label: `${edge.node1Id}-${edge.node2Id}`,
     };
   });
 
@@ -35,6 +36,20 @@ export const GraphVisualisationDemo = () => {
     setText("Edge " + edge.id + " clicked");
   }
 
+  const myRenderNode = ({size, color, opacity, id}) => (
+    <group>
+      <mesh>
+        <circleGeometry args={[size]} />
+        <meshBasicMaterial
+          attach="material"
+          color={Number(id) % 2 == 0 ? "#FF0000" : "#00FF00"}
+          opacity={opacity}
+          transparent
+        />
+      </mesh>
+    </group>
+  );
+
   return (
     <>
       <p>{text}</p>
@@ -44,6 +59,7 @@ export const GraphVisualisationDemo = () => {
           edges={edges}
           onNodeClick={handleNodeClick}
           onEdgeClick={handleEdgeClick}
+          renderNode={myRenderNode}
         />
       </div>
     </>

--- a/frontend/src/Presentation/GraphVisualisationDemo.tsx
+++ b/frontend/src/Presentation/GraphVisualisationDemo.tsx
@@ -1,4 +1,4 @@
-import {GraphCanvas, InternalGraphEdge, InternalGraphNode} from "reagraph";
+import {GraphCanvas, InternalGraphEdge, InternalGraphNode, InternalGraphPosition} from "reagraph";
 import {useState} from "react";
 import {useNetwork} from "../NetworkModel/NetworkContext.tsx";
 
@@ -12,7 +12,7 @@ export const GraphVisualisationDemo = () => {
 
   const highlightedChannel = highlightedChannelId ? network.channels[highlightedChannelId] : null;
 
-  const nodes = Object.values(network.nodes).map(node => {
+  const visNodes = Object.values(network.nodes).map(node => {
     return {
       id: node.id,
       label: node.id,
@@ -22,7 +22,7 @@ export const GraphVisualisationDemo = () => {
     };
   });
 
-  const edges = Object.values(network.edges).map(edge => {
+  const visEdges = Object.values(network.edges).map(edge => {
     return {
       source: edge.node1Id,
       target: edge.node2Id,
@@ -43,16 +43,28 @@ export const GraphVisualisationDemo = () => {
     setText("Edge " + edge.id + " clicked");
   }
 
+  const calcNodeCoordinates = (id: string) => {
+    const center = {latitude: 52.2297, longitude: 21.0122}; // Warsaw
+    const scale = 50;
+
+    const node = network.nodes[id];
+    const x = (node.longitude - center.longitude) * scale;
+    const y = (node.latitude - center.latitude) * scale;
+    return {x, y, z: 1} as InternalGraphPosition;
+  }
+
   return (
     <>
       <p>{text}</p>
       <div style={{position: "fixed", top: "30%", width: '45%', height: '50%'}}>
         <GraphCanvas
-          nodes={nodes}
-          edges={edges}
+          nodes={visNodes}
+          edges={visEdges}
           onNodeClick={handleNodeClick}
           onEdgeClick={handleEdgeClick}
           edgeArrowPosition={"none"}
+          layoutType={"custom"}
+          layoutOverrides={({getNodePosition: calcNodeCoordinates})}
         />
       </div>
     </>

--- a/frontend/src/Presentation/GraphVisualisationDemo.tsx
+++ b/frontend/src/Presentation/GraphVisualisationDemo.tsx
@@ -4,13 +4,13 @@ import {useNetwork} from "../NetworkModel/NetworkContext.tsx";
 
 export const GraphVisualisationDemo = () => {
   const [text, setText] = useState("");
-  const {network} = useNetwork();
+  const {network, highlightedChannelId} = useNetwork();
 
   if (!network) {
     return <p>Network not loaded</p>;
   }
 
-  const highlightedChannel = network.channels.C2;
+  const highlightedChannel = highlightedChannelId ? network.channels[highlightedChannelId] : null;
 
   const nodes = Object.values(network.nodes).map(node => {
     return {
@@ -47,7 +47,7 @@ export const GraphVisualisationDemo = () => {
         <circleGeometry args={[size]}/>
         <meshBasicMaterial
           attach="material"
-          color={highlightedChannel.nodes.includes(id) ? "rgba(11,154,138,0.62)" : "rgba(14,97,140,0.62)"}
+          color={highlightedChannel?.nodes.includes(id) ? "rgba(11,154,138,0.62)" : "rgba(14,97,140,0.62)"}
           opacity={opacity}
           transparent
         />
@@ -66,7 +66,7 @@ export const GraphVisualisationDemo = () => {
           onEdgeClick={handleEdgeClick}
           renderNode={myRenderNode}
           edgeArrowPosition={"none"}
-          actives={highlightedChannel.edges}
+          actives={highlightedChannel?.edges}
         />
       </div>
     </>

--- a/frontend/src/Presentation/GraphVisualisationDemo.tsx
+++ b/frontend/src/Presentation/GraphVisualisationDemo.tsx
@@ -1,12 +1,16 @@
 import {GraphCanvas, InternalGraphEdge, InternalGraphNode, NodeRendererProps} from "reagraph";
 import {useState} from "react";
-import {demoNetwork} from "../NetworkModel/demoNetwork.ts";
+import {useNetwork} from "../NetworkModel/NetworkContext.tsx";
 
 export const GraphVisualisationDemo = () => {
   const [text, setText] = useState("");
-  const network = demoNetwork;
-  const highlightedChannel = network.channels.C2;
+  const {network} = useNetwork();
 
+  if (!network) {
+    return <p>Network not loaded</p>;
+  }
+
+  const highlightedChannel = network.channels.C2;
 
   const nodes = Object.values(network.nodes).map(node => {
     return {

--- a/frontend/src/Presentation/GraphVisualisationDemo.tsx
+++ b/frontend/src/Presentation/GraphVisualisationDemo.tsx
@@ -1,4 +1,4 @@
-import {GraphCanvas, InternalGraphEdge, InternalGraphNode} from "reagraph";
+import {GraphCanvas, InternalGraphEdge, InternalGraphNode, NodeRendererProps} from "reagraph";
 import {useState} from "react";
 import {demoNetwork} from "../NetworkModel/demoNetwork.ts";
 
@@ -37,10 +37,10 @@ export const GraphVisualisationDemo = () => {
     setText("Edge " + edge.id + " clicked");
   }
 
-  const myRenderNode = ({size, opacity, id}) => (
+  const myRenderNode = ({size, opacity, id}: NodeRendererProps) => (
     <group>
       <mesh>
-        <circleGeometry args={[size]} />
+        <circleGeometry args={[size]}/>
         <meshBasicMaterial
           attach="material"
           color={highlightedChannel.nodes.includes(id) ? "rgba(11,154,138,0.62)" : "rgba(14,97,140,0.62)"}

--- a/frontend/src/Presentation/GraphVisualisationDemo.tsx
+++ b/frontend/src/Presentation/GraphVisualisationDemo.tsx
@@ -5,6 +5,8 @@ import {demoNetwork} from "../NetworkModel/demoNetwork.ts";
 export const GraphVisualisationDemo = () => {
   const [text, setText] = useState("");
   const network = demoNetwork;
+  const highlightedChannel = network.channels.C2;
+
 
   const nodes = Object.values(network.nodes).map(node => {
     return {
@@ -12,7 +14,6 @@ export const GraphVisualisationDemo = () => {
       label: node.id,
       x: node.longitude,
       y: node.latitude,
-      color: '#FF0000'
     };
   });
 
@@ -36,13 +37,13 @@ export const GraphVisualisationDemo = () => {
     setText("Edge " + edge.id + " clicked");
   }
 
-  const myRenderNode = ({size, color, opacity, id}) => (
+  const myRenderNode = ({size, opacity, id}) => (
     <group>
       <mesh>
         <circleGeometry args={[size]} />
         <meshBasicMaterial
           attach="material"
-          color={Number(id) % 2 == 0 ? "#FF0000" : "#00FF00"}
+          color={highlightedChannel.nodes.includes(id) ? "rgba(11,154,138,0.62)" : "rgba(14,97,140,0.62)"}
           opacity={opacity}
           transparent
         />
@@ -60,6 +61,8 @@ export const GraphVisualisationDemo = () => {
           onNodeClick={handleNodeClick}
           onEdgeClick={handleEdgeClick}
           renderNode={myRenderNode}
+          edgeArrowPosition={"none"}
+          actives={highlightedChannel.edges}
         />
       </div>
     </>

--- a/frontend/src/Presentation/GraphVisualisationDemo.tsx
+++ b/frontend/src/Presentation/GraphVisualisationDemo.tsx
@@ -18,6 +18,7 @@ export const GraphVisualisationDemo = () => {
       label: node.id,
       x: node.longitude,
       y: node.latitude,
+      fill: "#FF0000"
     };
   });
 
@@ -27,6 +28,7 @@ export const GraphVisualisationDemo = () => {
       target: edge.node2Id,
       id: edge.id,
       label: `${edge.node1Id}-${edge.node2Id}`,
+      fill: '#FF0000'
     };
   });
 
@@ -41,20 +43,6 @@ export const GraphVisualisationDemo = () => {
     setText("Edge " + edge.id + " clicked");
   }
 
-  const myRenderNode = ({size, opacity, id}: NodeRendererProps) => (
-    <group>
-      <mesh>
-        <circleGeometry args={[size]}/>
-        <meshBasicMaterial
-          attach="material"
-          color={highlightedChannel?.nodes.includes(id) ? "rgba(11,154,138,0.62)" : "rgba(14,97,140,0.62)"}
-          opacity={opacity}
-          transparent
-        />
-      </mesh>
-    </group>
-  );
-
   return (
     <>
       <p>{text}</p>
@@ -64,7 +52,6 @@ export const GraphVisualisationDemo = () => {
           edges={edges}
           onNodeClick={handleNodeClick}
           onEdgeClick={handleEdgeClick}
-          renderNode={myRenderNode}
           edgeArrowPosition={"none"}
           actives={highlightedChannel?.edges}
         />

--- a/frontend/src/Presentation/PresentationPage.tsx
+++ b/frontend/src/Presentation/PresentationPage.tsx
@@ -1,12 +1,25 @@
 import {GraphVisualisationDemo} from "./GraphVisualisationDemo.tsx";
 import {DownloadReport} from "../ReportGeneration/DownloadReport.tsx";
+import {useNetwork} from "../NetworkModel/NetworkContext.tsx";
 
 export const PresentationPage = () => {
+  const {network, setHighlightedChannelId} = useNetwork();
+
+  const onDummyGenerateChannel = () => {
+    if (!network) {
+      return;
+    }
+
+    const firstChannel = Object.keys(network.channels)[0];
+    setHighlightedChannelId(firstChannel);
+  }
+
   return (
     <div style={{display: 'flex', flexDirection: 'column', margin: '0 auto', placeItems: 'center'}}>
       <h1>Presentation</h1>
       <div style={{position: 'fixed', top: "20%", left: "5%", width: '45%', height: '100%', overflow: 'auto'}}>
         <DownloadReport/>
+        <button onClick={onDummyGenerateChannel}>Find channel</button>
       </div>
       <div style={{position: 'fixed', top: "20%", right: "5%", width: '45%', height: '100%', overflow: 'auto'}}>
         <GraphVisualisationDemo/>

--- a/frontend/src/Presentation/PresentationPage.tsx
+++ b/frontend/src/Presentation/PresentationPage.tsx
@@ -5,13 +5,14 @@ import {useNetwork} from "../NetworkModel/NetworkContext.tsx";
 export const PresentationPage = () => {
   const {network, setHighlightedChannelId} = useNetwork();
 
-  const onDummyGenerateChannel = () => {
+  const onFindChannel = () => {
     if (!network) {
       return;
     }
-
-    const firstChannel = Object.keys(network.channels)[0];
-    setHighlightedChannelId(firstChannel);
+    setTimeout(() => {
+      const firstChannel = Object.keys(network.channels)[0];
+      setHighlightedChannelId(firstChannel);
+    }, 3000);
   }
 
   return (
@@ -19,7 +20,7 @@ export const PresentationPage = () => {
       <h1>Presentation</h1>
       <div style={{position: 'fixed', top: "20%", left: "5%", width: '45%', height: '100%', overflow: 'auto'}}>
         <DownloadReport/>
-        <button onClick={onDummyGenerateChannel}>Find channel</button>
+        <button onClick={onFindChannel}>Find channel</button>
       </div>
       <div style={{position: 'fixed', top: "20%", right: "5%", width: '45%', height: '100%', overflow: 'auto'}}>
         <GraphVisualisationDemo/>


### PR DESCRIPTION
* Model sieci w oddzielnym miejscu (nie ingerowałem w DataImporter bo jest w trakcie pracy)
* Context przechowujący globalny stan, np sieć, użycie przez `useNetwork()`
* Przykładowe dane do wizualizacji
* Ułożenie węzłów na podstawie współrzędnych geograficznych - nie jest używana żadna sprytna projekcja jak na mapach
* Kolorowanie węzłów i krawędzi
* Guzik, który po 3 sekundach zmienia kolor pierwszego kanału w sieci na wizualizacji